### PR TITLE
remove workload identity conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ default values, and can be overwritten via the helm `--set` flag.
 | `authorizedKeysBase64`             | Base64 encoded `authorized_keys`           | must be set                            |
 | `hostKeyBase64`                    | Base64 encoded `ssh_host_ed25519_key`      | must be set                            |
 | `sshd_config`                      | SSH server configuration                   | see `values.yaml`                      |
-| `cloudsql.useWorkloadIdentity`     | Use Workload Identity service account      | false                                  |
 | `cloudsql.serviceAccountName`      | Name of Workload Identity service account  | unset                                  |
-| `cloudsql.serviceAccountKeyBase64` | Base64 encoded Google service account JSON | must be set if not useWorkloadIdentity |
 | `cloudsql.instances[0].project`    | Cloud SQL instance project                 | `my-project`                           |
 | `cloudsql.instances[0].region`     | Cloud SQL instance region                  | `us-west1`                             |
 | `cloudsql.instances[0].instance`   | Cloud SQL instance name                    | `sql_instance`                         |

--- a/sqlproxy-ssh-tunnel/templates/deployment.yaml
+++ b/sqlproxy-ssh-tunnel/templates/deployment.yaml
@@ -16,7 +16,6 @@ spec:
         app: {{.Values.name}}
     spec:
       dnsPolicy: ClusterFirst
-{{- if .Values.cloudsql.useWorkloadIdentity }}
       serviceAccountName: {{.Values.cloudsql.serviceAccountName}}
       tolerations:
       - key: "workload-identity"
@@ -25,7 +24,6 @@ spec:
         effect: "NoSchedule"
       nodeSelector:
         workload-identity: "enabled"
-{{- end }}
       containers:
         - name: {{.Values.name}}
           image: {{.Values.image}}
@@ -62,13 +60,6 @@ spec:
             - -instances={{- range .Values.cloudsql.instances -}}
                            {{ .project }}:{{ .region }}:{{ .instance }}=tcp:0.0.0.0:{{ .port }},
                          {{- end }}
-{{- if not .Values.cloudsql.useWorkloadIdentity }}
-            - -credential_file=/secrets/cloudsql/sql_credentials.json
-          volumeMounts:
-            - name: sqlproxy-credential
-              mountPath: /secrets/cloudsql
-              readOnly: true
-{{- end }}
 {{- if .Values.reverseTunnel }}
         - name: reverse-tunnel
           image: {{.Values.image}}
@@ -106,8 +97,3 @@ spec:
           secret:
             defaultMode: 0600
             secretName: reverse-tunnel-private-key
-{{- if not .Values.cloudsql.useWorkloadIdentity }}
-        - name: sqlproxy-credential
-          secret:
-            secretName: sqlproxy-credential
-{{- end }}

--- a/sqlproxy-ssh-tunnel/templates/sqlproxy_credential.yaml
+++ b/sqlproxy-ssh-tunnel/templates/sqlproxy_credential.yaml
@@ -1,9 +1,0 @@
-{{- if not .Values.cloudsql.useWorkloadIdentity }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: sqlproxy-credential
-type: Opaque
-data:
-  sql_credentials.json: {{.Values.cloudsql.serviceAccountKeyBase64}}
-{{- end }}

--- a/sqlproxy-ssh-tunnel/values.yaml
+++ b/sqlproxy-ssh-tunnel/values.yaml
@@ -5,9 +5,7 @@ authorizedKeysBase64: "nice long base64 encoded string of authorized_keys"
 hostKeyBase64: "nice long base64 encoded string of host key"
 
 cloudsql:
-  useWorkloadIdentity: false
   serviceAccountName: "sqlproxy-workload-identity"
-  serviceAccountKeyBase64: "nice long base64 encoded of Google service account JSON - if not using workload identity"
   instances:
     - instance: "sql_instance"
       project: "my-project"


### PR DESCRIPTION
We have the sqlproxy running using workload identities in all environments now. Theses changes remove the conditionals as there is no need for them now.