### PR TITLE
Add loadbalancer source range

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ default values, and can be overwritten via the helm `--set` flag.
 | `cloudsql.instances[0].port`       | Port to bind Cloud SQL instance to         | 3306                                   |
 | `service.loadBalancerPort`         | Port you want to be exposed to the outside | 22                                     |
 | `service.loadBalancerIP`           | Load balancer IP (if pre-allocated)        | unset                                  |
+| `service.sourceRanges`             | Load balancer firewall source IPs          | unset                                  |
 | `reverseTunnel.privateKeyBase64`   | Base64 encoded `ssh_client_ed25519_key`    | unset                                  |
 | `reverseTunnel.sshUser`            | Reverse tunnel server user                 | unset                                  |
 | `reverseTunnel.sshHost`            | Reverse tunnel server host                 | unset                                  |

--- a/sqlproxy-ssh-tunnel/templates/service.yaml
+++ b/sqlproxy-ssh-tunnel/templates/service.yaml
@@ -14,3 +14,9 @@ spec:
 {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
 {{- end }}
+{{- if .Values.service.sourceRanges }}
+  loadBalancerSourceRanges: 
+    {{- range .Values.service.sourceRanges }}
+    - {{ . }}
+    {{- end }}
+{{- end }}

--- a/sqlproxy-ssh-tunnel/values.yaml
+++ b/sqlproxy-ssh-tunnel/values.yaml
@@ -17,6 +17,9 @@ cloudsql:
 service:
   loadBalancerPort: 22
   # loadBalancerIP: 10.0.0.1
+  # sourceRanges: 
+  #   - 127.0.0.1
+  #   - 192.168.0.1
 
 # reverseTunnel:
 #   privateKeyBase64: "base64 encoded string of client private key"


### PR DESCRIPTION
Adds the ability to configure the load balancer source IP addresses and ranges. When creating a k8s Service with the type `LoadBalancer` GKE by [default ](https://cloud.google.com/kubernetes-engine/docs/concepts/firewall-rules#service-fws)adds a firewall rule that allows access from all IPs (`0.0.0.0/0`).

This change adds the value `service.sourceRanges`, which should be a list. Allowing the user to restrict access to the service by IP address or IP range. By default it is not set.